### PR TITLE
Prevent Desert Surface 7 and Light 3 skips

### DIFF
--- a/App/Main.cpp
+++ b/App/Main.cpp
@@ -21,6 +21,7 @@
 #define DISABLE_SNIPES 0x407
 #define SPEED_UP_AUTOSCROLLERS 0x408
 #define DOUBLE_RANDOMIZER_MODE 0x409
+#define DISABLE_DESERT_SKIPS 0x410
 
 /* ------- Temp ------- */
 #include "Puzzle.h"
@@ -107,6 +108,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
                         g_randomizer->AdjustSpeed();
                     }
                     g_randomizer->SetDoubleRandomizerMode(IsDlgButtonChecked(g_hwnd, DOUBLE_RANDOMIZER_MODE));
+                    g_randomizer->SetPreventDesertSkips(IsDlgButtonChecked(g_hwnd, DISABLE_DESERT_SKIPS));
                     if (IsDlgButtonChecked(g_hwnd, CHALLENGE_ONLY)) {
                         SetWindowText(g_randomizerStatus, L"Randomizing Challenge...");
                         g_randomizer->RandomizeChallenge();
@@ -145,6 +147,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
                 break;
             case DOUBLE_RANDOMIZER_MODE:
                 CheckDlgButton(hwnd, DOUBLE_RANDOMIZER_MODE, !IsDlgButtonChecked(hwnd, DOUBLE_RANDOMIZER_MODE));
+                break;
+            case DISABLE_DESERT_SKIPS:
+                CheckDlgButton(hwnd, DISABLE_DESERT_SKIPS, !IsDlgButtonChecked(hwnd, DISABLE_DESERT_SKIPS));
                 break;
             case TMP1:
                 {
@@ -269,6 +274,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
     CreateLabel(30, 340, 205, L"Speed up various autoscrollers");
     CreateCheckbox(10, 360, DOUBLE_RANDOMIZER_MODE);
     CreateLabel(30, 360, 165, L"Double randomizer mode");
+    CreateCheckbox(10, 380, DISABLE_DESERT_SKIPS);
+    CreateLabel(30, 380, 280, L"Disable Desert Surface 7 and Light 3 skips");
+    CheckDlgButton(g_hwnd, DISABLE_DESERT_SKIPS, TRUE);
 
     // CreateButton(200, 50, 200, L"Test RNG", TMP5);
     // g_rngDebug = CreateWindow(L"STATIC", L"",

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -270,11 +270,15 @@ void Randomizer::RandomizeDesert() {
     // 0x09DA6 Surface 5
     // 0x09F94 Surface 8
     // 0x0117A Flood 4
-    SwapWithRandomPanel(0x0A053, copyWithoutElements(desertPanels, { 0x09DA6, 0x09F94, 0x0117A }), SWAP::LINES);
+    int surfaceSevenSwapepdWith = SwapWithRandomPanel(0x0A053, copyWithoutElements(desertPanels, { 0x09DA6, 0x09F94, 0x0117A }), SWAP::LINES);
     // In order to require that both latches are opened, Light 3 cannot be
-    // swapped with:
-    // 0x012D7 Final Far
-    SwapWithRandomPanel(0x0A02D, copyWithoutElements(desertPanels, { 0x012D7 }), SWAP::LINES);
+    // swapped with Final Far. If Surface 7 has been swapped with Final Far, we
+    // need to ban that panel instead.
+    int finalFarId = 0x012D7;
+    if (surfaceSevenSwapepdWith == finalFarId) {
+        finalFarId = 0x0A053;
+    }
+    SwapWithRandomPanel(0x0A02D, copyWithoutElements(desertPanels, { finalFarId }), SWAP::LINES);
     // The remaining panels can be safely shuffled amongst themselves.
     std::vector<int> remainingDesertPanels = copyWithoutElements(desertPanels, { 0x0A053, 0x0A02D });
     Randomize(remainingDesertPanels, SWAP::LINES);
@@ -423,11 +427,12 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
     return RandomizeRange(panels, flags, 0, panels.size());
 }
 
-void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
+int Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
     const int target = Random::RandInt(0, static_cast<int>(possible_panels.size()) - 1);
     if (panel1 != possible_panels[target]) {
         SwapPanels(panel1, possible_panels[target], flags);
     }
+    return target;
 }
 
 // Range is [start, end)

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -248,6 +248,11 @@ void Randomizer::SetDoubleRandomizerMode(bool val)
     _doubleRandomizer = val;
 }
 
+void Randomizer::SetPreventDesertSkips(bool val)
+{
+    _preventDesertSkips = val;
+}
+
 // Private methods
 void Randomizer::RandomizeTutorial() {
     // Disable tutorial cursor speed modifications (not working?)
@@ -265,23 +270,27 @@ void Randomizer::RandomizeSymmetry() {
 }
 
 void Randomizer::RandomizeDesert() {
-    // In order to require that all three latches are opened, Surface 7 cannot
-    // be swapped with:
-    // 0x09DA6 Surface 5
-    // 0x09F94 Surface 8
-    // 0x0117A Flood 4
-    int surfaceSevenSwapepdWith = SwapWithRandomPanel(0x0A053, copyWithoutElements(desertPanels, { 0x09DA6, 0x09F94, 0x0117A }), SWAP::LINES);
-    // In order to require that both latches are opened, Light 3 cannot be
-    // swapped with Final Far. If Surface 7 has been swapped with Final Far, we
-    // need to ban that panel instead.
-    int finalFarId = 0x012D7;
-    if (surfaceSevenSwapepdWith == finalFarId) {
-        finalFarId = 0x0A053;
+    if (_preventDesertSkips) {
+        // In order to require that all three latches are opened, Surface 7
+        // cannot be swapped with:
+        // 0x09DA6 Surface 5
+        // 0x09F94 Surface 8
+        // 0x0117A Flood 4
+        int surfaceSevenSwappedWith = SwapWithRandomPanel(0x0A053, copyWithoutElements(desertPanels, { 0x09DA6, 0x09F94, 0x0117A }), SWAP::LINES);
+        // In order to require that both latches are opened, Light 3 cannot be
+        // swapped with Final Far. If Surface 7 has been swapped with Final Far,
+        // we need to ban that panel instead.
+        int finalFarId = 0x012D7;
+        if (surfaceSevenSwappedWith == finalFarId) {
+            finalFarId = 0x0A053;
+        }
+        SwapWithRandomPanel(0x0A02D, copyWithoutElements(desertPanels, { finalFarId }), SWAP::LINES);
+        // The remaining panels can be safely shuffled amongst themselves.
+        std::vector<int> remainingDesertPanels = copyWithoutElements(desertPanels, { 0x0A053, 0x0A02D });
+        Randomize(remainingDesertPanels, SWAP::LINES);
+    } else {
+        Randomize(desertPanels, SWAP::LINES);
     }
-    SwapWithRandomPanel(0x0A02D, copyWithoutElements(desertPanels, { finalFarId }), SWAP::LINES);
-    // The remaining panels can be safely shuffled amongst themselves.
-    std::vector<int> remainingDesertPanels = copyWithoutElements(desertPanels, { 0x0A053, 0x0A02D });
-    Randomize(remainingDesertPanels, SWAP::LINES);
     Randomize(desertPanelsWide, SWAP::LINES);
 
     // Turn off desert surface 8

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -265,7 +265,19 @@ void Randomizer::RandomizeSymmetry() {
 }
 
 void Randomizer::RandomizeDesert() {
-    Randomize(desertPanels, SWAP::LINES);
+    // In order to require that all three latches are opened, Surface 7 cannot
+    // be swapped with:
+    // 0x09DA6 Surface 5
+    // 0x09F94 Surface 8
+    // 0x0117A Flood 4
+    SwapWithRandomPanel(0x0A053, copyWithoutElements(desertPanels, { 0x09DA6, 0x09F94, 0x0117A }), SWAP::LINES);
+    // In order to require that both latches are opened, Light 3 cannot be
+    // swapped with:
+    // 0x012D7 Final Far
+    SwapWithRandomPanel(0x0A02D, copyWithoutElements(desertPanels, { 0x012D7 }), SWAP::LINES);
+    // The remaining panels can be safely shuffled amongst themselves.
+    std::vector<int> remainingDesertPanels = copyWithoutElements(desertPanels, { 0x0A053, 0x0A02D });
+    Randomize(remainingDesertPanels, SWAP::LINES);
     Randomize(desertPanelsWide, SWAP::LINES);
 
     // Turn off desert surface 8
@@ -409,6 +421,13 @@ void Randomizer::RandomizeAudioLogs() {
 
 void Randomizer::Randomize(std::vector<int>& panels, int flags) {
     return RandomizeRange(panels, flags, 0, panels.size());
+}
+
+void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
+    const int target = Random::RandInt(0, static_cast<int>(possible_panels.size()) - 1);
+    if (panel1 != possible_panels[target]) {
+        SwapPanels(panel1, possible_panels[target], flags);
+    }
 }
 
 // Range is [start, end)

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -432,7 +432,7 @@ int Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible
     if (panel1 != possible_panels[target]) {
         SwapPanels(panel1, possible_panels[target], flags);
     }
-    return target;
+    return possible_panels[target];
 }
 
 // Range is [start, end)

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -39,6 +39,7 @@ private:
     void RandomizeAudioLogs();
 
     void Randomize(std::vector<int>& panels, int flags);
+    void SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
     void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
     void SwapPanels(int panel1, int panel2, int flags);
     void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -39,7 +39,7 @@ private:
     void RandomizeAudioLogs();
 
     void Randomize(std::vector<int>& panels, int flags);
-    void SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
+    int SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
     void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
     void SwapPanels(int panel1, int panel2, int flags);
     void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -12,6 +12,7 @@ public:
     void RandomizeLasers();
     void PreventSnipes();
     void SetDoubleRandomizerMode(bool val);
+    void SetPreventDesertSkips(bool val);
 
     enum SWAP {
         NONE = 0,
@@ -47,6 +48,7 @@ private:
 
     std::shared_ptr<Memory> _memory;
     bool _doubleRandomizer = false;
+    bool _preventDesertSkips = false;
 
     friend class SwapTests_Shipwreck_Test;
 };


### PR DESCRIPTION
If Desert Surface 7 is swapped with Surface 5, Surface 8, or Flood 4, you are not required to open all three latches to solve the panel. Similarly, if Light 3 is swapped with Final Far, you only have to open one of the two latches. The improbability of such swaps happening makes running Low% inviable in the same way that the old Quarry Laser exploit did, so this patch prevents those specific swaps from happening. Surface 7 and Light 3 can still be swapped with any other unbanned panel, including each other, and themselves.

This would require a major version bump because it would definitely invalidate seeds.