### PR TITLE
Made content swaps consistent across multiple invocations

### DIFF
--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -157,7 +157,7 @@ void Randomizer::Randomize() {
             0x3C125, // Mill Control Room Extra Panel
             0x09E85, // Tunnels Town Shortcut
         });
-        Randomize(upDownPanelsSetThreeDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(upDownPanelsSetThreeDoubleMode, SWAP::LINES | SWAP::COLORS);
         // The four pivot panels in Treehouse must be solveable in the up, left,
         // and right positions. However, the other panels in the pools those
         // panels are found in may not be solveable in all three directions
@@ -179,17 +179,17 @@ void Randomizer::Randomize() {
         std::vector<int> upDownPanelsSetZeroDoubleMode = copyWithoutElements(upDownPanelsSetZero, {0x288AA});
         std::vector<int> upDownPanelsSetOneDoubleMode = copyWithoutElements(upDownPanelsSetOne, {0x288AA});
         std::vector<int> upDownPanelsSetTwoDoubleMode = copyWithoutElements(upDownPanelsSetTwo, {0x288AA});
-        Randomize(upDownPanelsSetZeroDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetOneDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetTwoDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(upDownPanelsSetZeroDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(upDownPanelsSetOneDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(upDownPanelsSetTwoDoubleMode, SWAP::LINES | SWAP::COLORS);
         Randomize(upDownPanelsSetFour, SWAP::LINES | SWAP::COLORS);
         // Many puzzles either crash the game or do not solve properly when
         // swapped with Swamp Entry. To make things simpler, we will just remove
         // that panel from both pools it is found in.
         std::vector<int> quarryLaserOptionsDoubleMode = copyWithoutElements(quarryLaserOptions, doubleModeBannedSquarePanels);
         std::vector<int> squarePanelsDoubleMode = copyWithoutElements(squarePanels, doubleModeBannedSquarePanels);
-        Randomize(quarryLaserOptionsDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(squarePanelsDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(quarryLaserOptionsDoubleMode, SWAP::LINES | SWAP::COLORS);
+        RandomizeInPlace(squarePanelsDoubleMode, SWAP::LINES | SWAP::COLORS);
     } else {
         Randomize(upDownPanelsSetZero, SWAP::LINES | SWAP::COLORS);
         Randomize(upDownPanelsSetOne, SWAP::LINES | SWAP::COLORS);
@@ -403,11 +403,15 @@ void Randomizer::RandomizeChallenge() {
 void Randomizer::RandomizeAudioLogs() {
     std::vector<int> randomOrder(audiologs.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    Randomize(randomOrder, SWAP::NONE);
+    RandomizeInPlace(randomOrder, SWAP::NONE);
     ReassignNames(audiologs, randomOrder);
 }
 
-void Randomizer::Randomize(std::vector<int>& panels, int flags) {
+void Randomizer::Randomize(std::vector<int> panels, int flags) {
+    return RandomizeInPlace(panels, flags);
+}
+
+void Randomizer::RandomizeInPlace(std::vector<int>& panels, int flags) {
     return RandomizeRange(panels, flags, 0, panels.size());
 }
 

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -38,7 +38,8 @@ private:
     void RandomizeMountain();
     void RandomizeAudioLogs();
 
-    void Randomize(std::vector<int>& panels, int flags);
+    void Randomize(std::vector<int> panels, int flags);
+    void RandomizeInPlace(std::vector<int>& panels, int flags);
     void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
     void SwapPanels(int panel1, int panel2, int flags);
     void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});


### PR DESCRIPTION
Previously, there was a bug where randomizing with the same seed would not always produce the same panel swaps. Specifically, these two workflows would produce different results:

* Start a new game in The Witness. Open the randomizer and randomize using a set seed (seed A).
* Start a new game in The Witness. Open the randomizer and randomize using either a random or a set seed. Then start another new game in The Witness. Without closing the randomizer, randomize using seed A from the first workflow.

This discrepancy happened because the randomizer would modify the ordering of the identifier lists used for randomization. Any given seed would always cause the swaps to be carried out within the list in the same way, but because the content of the list had already been changed, and that change persisted after starting a new game in The Witness, the result of randomization would differ. This change prevents the identifier lists from being modified by instead making copies of the lists during randomization.