### PR TITLE
Revamped pools for special panels

### DIFF
--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -101,6 +101,103 @@ std::vector<int> tutorialBackLeftOptions = {
     0x0A3B5, // Tutorial Back Left
 };
 
+std::vector<int> mountainBlueOneOptions = {
+    0x00182, // Tutorial Bend
+    0x00293, // Tutorial Front Center
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x00087, // Glass Factory Vertical Symmetry 2
+    0x00059, // Glass Factory Vertical Symmetry 3
+    0x00062, // Glass Factory Vertical Symmetry 4
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00083, // Glass Factory Rotational Symmetry 3
+    0x00084, // Glass Factory Melting 1
+    0x00082, // Glass Factory Melting 2
+    0x0343A, // Glass Factory Melting 3
+    0x00026, // Symmetry Island Black Dots 5
+    0x0007C, // Symmetry Island Colored Dots 1
+    0x0007E, // Symmetry Island Colored Dots 2
+    0x00075, // Symmetry Island Colored Dots 3
+    0x00073, // Symmetry Island Colored Dots 4
+    0x00065, // Symmetry Island Fading Lines 1
+    0x0006D, // Symmetry Island Fading Lines 2
+    0x0006F, // Symmetry Island Fading Lines 4
+    0x00070, // Symmetry Island Fading Lines 5
+    0x17CE7, // Desert Discard
+    0x01E5A, // Mill Entry Door Left
+    0x01489, // Mill Lower Row 2
+    0x00557, // Mill Upper Row 1
+    0x005F1, // Mill Upper Row 2
+    0x00620, // Mill Upper Row 3
+    0x03686, // Mill Upper Row 7
+    0x3C125, // Mill Control Room 2
+    0x021B0, // Boathouse Erasers and Shapers 3
+    0x021AF, // Boathouse Erasers and Shapers 4
+    0x021B5, // Boathouse Erasers and Stars 1
+    0x021B6, // Boathouse Erasers and Stars 2
+    0x021B7, // Boathouse Erasers and Stars 3
+    0x021BB, // Boathouse Erasers and Stars 4
+    0x3C124, // Boathouse Erasers and Stars 7
+    0x0A3CC, // Boathouse Erasers Shapers and Stars 4
+    0x0288C, // Treehouse Door 1
+    0x17D8F, // Treehouse Yellow 2
+    0x0A182, // Treehouse Door 3
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DB5, // Treehouse Left Orange 2
+    0x17DD7, // Treehouse Left Orange 5
+    0x17DB8, // Treehouse Left Orange 7
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DEC, // Treehouse Left Orange 12
+    0x17DB0, // Treehouse Left Orange 14
+    0x17D88, // Treehouse Right Orange 1
+    0x17DB4, // Treehouse Right Orange 2
+    0x17D8C, // Treehouse Right Orange 3
+    0x17DCD, // Treehouse Right Orange 5
+    0x17D8E, // Treehouse Right Orange 9
+    0x17E5F, // Treehouse Green 6
+    0x019E7, // Keep Hedges 3
+    0x17D27, // Keep Discard
+    0x28938, // Town Apple Tree
+    0x28AC7, // Town Blue 1
+    0x28AC8, // Town Blue 2
+    0x28ACA, // Town Blue 3
+    0x17C71, // Town Rooftop Discard
+    0x17C2E, // Bunker Entry Door
+    0x0056E, // Swamp Entry
+    0x00474, // Swamp Tutorial 4
+    0x00984, // Swamp Tutorial 10
+    0x00986, // Swamp Tutorial 11
+    0x00985, // Swamp Tutorial 12
+    0x00987, // Swamp Tutorial 13
+    0x181A9, // Swamp Tutorial 14
+    0x00982, // Swamp Red 1
+    0x00999, // Swamp Discontinuous 1
+    0x00007, // Swamp Rotation Tutorial 1
+    0x009AF, // Swamp Blue Underwater 4
+    0x003B2, // Swamp Rotation Advanced 1
+    0x009A6, // Swamp Purple Tetris
+    0x00001, // Swamp Red Underwater 1
+    0x014D2, // Swamp Red Underwater 2
+    0x014D4, // Swamp Red Underwater 3
+    0x014D1, // Swamp Red Underwater 4
+    0x17C05, // Swamp Laser Shortcut 1
+    0x17C02, // Swamp Laser Shortcut 2
+    0x17F9B, // Jungle Discard
+    0x09FD4, // Mountain 2 Rainbow 2
+    0x17F93, // Mountain 2 Discard
+    0x0008F, // UTM Invisible Dots 1
+    0x0008B, // UTM Invisible Dots 3
+    0x0008C, // UTM Invisible Dots 4
+    0x0008A, // UTM Invisible Dots 5
+    0x00027, // UTM Invisible Dots Symmetry 1
+    0x00028, // UTM Invisible Dots Symmetry 2
+    0x32966, // UTM Treehouse
+    0x018A0, // UTM Blue Easy Symmetry
+
+    0x33AF5, // Mountain 1 Blue 1
+};
+
 std::vector<int> utmElevatorControls = {
     0x335AB, // UTM In Elevator Control
     0x3369D, // UTM Lower Elevator Control

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -17,14 +17,7 @@ std::vector<int> lasers = {
     0x19650, // Shadows
 };
 
-// Note: Some of these (non-controls) are duplicated elsewhere
-// TODO: Gave up
-std::vector<int> leftRightPanels = {
-    0x01A54, // Glass Factory Entry
-    0x00086, // Glass Factory Vertical Symmetry 1
-    0x00087, // Glass Factory Vertical Symmetry 2
-    0x00059, // Glass Factory Vertical Symmetry 3
-    0x00062, // Glass Factory Vertical Symmetry 4
+std::vector<int> townWindmillControlOptions = {
     0x00025, // Symmetry Island Black Dots 4
     0x00026, // Symmetry Island Black Dots 5
     0x00072, // Symmetry Island Fading Lines 3
@@ -32,8 +25,7 @@ std::vector<int> leftRightPanels = {
     0x17D02, // Town Windmill Control
 };
 
-// Note: Some of these (non-controls) are duplicated elsewhere
-std::vector<int> upDownPanelsSetZero = {
+std::vector<int> symmetryDoorTwoOptions = {
     0x00070, // Symmetry Island Fading Lines 5
     0x01E5A, // Mill Entry Door Left
     0x28AC7, // Town Blue 1
@@ -48,7 +40,7 @@ std::vector<int> upDownPanelsSetZero = {
     0x1C349, // Inner Symmetry Island Entrance
 };
 
-std::vector<int> upDownPanelsSetOne = {
+std::vector<int> millElevatorControlOptions = {
     0x0008D, // Glass Factory Rotational Symmetry 1
     0x00081, // Glass Factory Rotational Symmetry 2
     0x00070, // Symmetry Island Fading Lines 5
@@ -64,7 +56,7 @@ std::vector<int> upDownPanelsSetOne = {
     0x17CC4, // Mill Elevator Control
 };
 
-std::vector<int> upDownPanelsSetTwo = {
+std::vector<int> utmPerspectiveFourOptions = {
     0x0008D, // Glass Factory Rotational Symmetry 1
     0x00081, // Glass Factory Rotational Symmetry 2
     0x00083, // Glass Factory Rotational Symmetry 3
@@ -94,7 +86,7 @@ std::vector<int> upDownPanelsSetTwo = {
     0x288AA, // UTM Perspective 4
 };
 
-std::vector<int> upDownPanelsSetThree = {
+std::vector<int> tutorialBackLeftOptions = {
     0x0008D, // Glass Factory Rotational Symmetry 1
     0x00081, // Glass Factory Rotational Symmetry 2
     0x00083, // Glass Factory Rotational Symmetry 3
@@ -124,7 +116,7 @@ std::vector<int> upDownPanelsSetThree = {
     0x0A3B5, // Tutorial Back Left
 };
 
-std::vector<int> upDownPanelsSetFour = {
+std::vector<int> utmElevatorControls = {
     0x335AB, // UTM In Elevator Control
     0x3369D, // UTM Lower Elevator Control
     0x335AC, // UTM Upper Elevator Control
@@ -222,235 +214,89 @@ std::vector<int> mountainMetaPanels = {
     0x09EFF, //Top Left
 };
 
-std::vector<int> quarryLaserOptions = {
-    0x00064, // Tutorial Straight
-    0x00182, // Tutorial Bend
-    0x0A3B2, // Tutorial Back Right
-    0x00295, // Tutorial Center Left
-    0x00293, // Tutorial Front Center
-    0x0005D, // Outside Tutorial Dots Tutorial 1
-    0x0005E, // Outside Tutorial Dots Tutorial 2
-    0x0005F, // Outside Tutorial Dots Tutorial 3
-    0x00060, // Outside Tutorial Dots Tutorial 4
-    0x00061, // Outside Tutorial Dots Tutorial 5
-    0x0001C, // Outside Tutorial Stones Tutorial 4
-    0x0001D, // Outside Tutorial Stones Tutorial 5
-    0x0001E, // Outside Tutorial Stones Tutorial 6
-    0x0001F, // Outside Tutorial Stones Tutorial 7
-    0x00020, // Outside Tutorial Stones Tutorial 8
-    0x033D4, // Outside Tutorial Vault
-    0x0A171, // Tutorial Optional Door 1
-    0x04CA4, // Tutorial Optional Door 2
-    0x17CFB, // Outside Tutorial Discard
-    0x3C12B, // Glass Factory Discard
-    0x000B0, // Symmetry Island Door 1
+std::vector<int> quarryLaserBanned = {
+    0x002C2, // Tutorial Front Left
+    0x018AF, // Outside Tutorial Stones Tutorial 1
+    0x0001B, // Outside Tutorial Stones Tutorial 2
+    0x012C9, // Outside Tutorial Stones Tutorial 3
+    0x00021, // Outside Tutorial Stones Tutorial 9
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x00087, // Glass Factory Vertical Symmetry 2
+    0x00059, // Glass Factory Vertical Symmetry 3
+    0x00062, // Glass Factory Vertical Symmetry 4
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00081, // Glass Factory Rotational Symmetry 2
+    0x00083, // Glass Factory Rotational Symmetry 3
+    0x00084, // Glass Factory Melting 1
+    0x00082, // Glass Factory Melting 2
+    0x0343A, // Glass Factory Melting 3
+    0x00022, // Symmetry Island Black Dots 1
+    0x00023, // Symmetry Island Black Dots 2
+    0x00024, // Symmetry Island Black Dots 3
+    0x00025, // Symmetry Island Black Dots 4
+    0x00026, // Symmetry Island Black Dots 5
     0x00079, // Symmetry Island Colored Dots 6
     0x00065, // Symmetry Island Fading Lines 1
-    0x00A52, // Symmetry Island Laser Yellow 1
-    0x00A57, // Symmetry Island Laser Yellow 2
-    0x00A5B, // Symmetry Island Laser Yellow 3
-    0x00A61, // Symmetry Island Laser Blue 1
-    0x00A64, // Symmetry Island Laser Blue 2
-    0x00A68, // Symmetry Island Laser Blue 3
-    0x17CE7, // Desert Discard
-    0x0CC7B, // Desert Vault
-    0x01E59, // Mill Entry Door Right
-    0x00E0C, // Mill Lower Row 1
-    0x01489, // Mill Lower Row 2
-    0x0148A, // Mill Lower Row 3
-    0x014D9, // Mill Lower Row 4
-    0x014E7, // Mill Lower Row 5
-    0x014E8, // Mill Lower Row 6
-    0x00557, // Mill Upper Row 1
-    0x005F1, // Mill Upper Row 2
-    0x00620, // Mill Upper Row 3
-    0x009F5, // Mill Upper Row 4
-    0x0146C, // Mill Upper Row 5
-    0x3C12D, // Mill Upper Row 6
-    0x03686, // Mill Upper Row 7
-    0x014E9, // Mill Upper Row 8
-    0x0367C, // Mill Control Room 1
+    0x01E5A, // Mill Entry Door Left
+    0x3C125, // Mill Control Room 2
     0x03677, // Mill Stairs Control
     0x17CF0, // Mill Discard
-    0x021D5, // Boathouse Ramp Activation Shapers
-    0x034D4, // Boathouse Ramp Activation Stars
-    0x021B3, // Boathouse Erasers and Shapers 1
-    0x021B4, // Boathouse Erasers and Shapers 2
-    0x021B0, // Boathouse Erasers and Shapers 3
-    0x021AF, // Boathouse Erasers and Shapers 4
-    0x021AE, // Boathouse Erasers and Shapers 5
-    0x021B5, // Boathouse Erasers and Stars 1
-    0x021B6, // Boathouse Erasers and Stars 2
-    0x021B7, // Boathouse Erasers and Stars 3
-    0x021BB, // Boathouse Erasers and Stars 4
-    0x09DB5, // Boathouse Erasers and Stars 5
-    0x09DB1, // Boathouse Erasers and Stars 6
-    0x3C124, // Boathouse Erasers and Stars 7
-    0x09DB4, // Boathouse Erasers Shapers and Stars 2
-    0x0A3CB, // Boathouse Erasers Shapers and Stars 3
-    0x0A3CC, // Boathouse Erasers Shapers and Stars 4
-    0x0A3D0, // Boathouse Erasers Shapers and Stars 5
-    0x09E57, // Quarry Entry Gate 1
-    0x17C09, // Quarry Entry Gate 2
-    0x02886, // Treehouse Door 2
-    0x17DAC, // Treehouse Yellow 4
-    0x17D9E, // Treehouse Yellow 5
-    0x17DB9, // Treehouse Yellow 6
-    0x17D9C, // Treehouse Yellow 7
-    0x17DC4, // Treehouse Yellow 9
-    0x0A182, // Treehouse Door 3
-    0x17DC8, // Treehouse First Purple 1
-    0x17DC7, // Treehouse First Purple 2
-    0x17CE4, // Treehouse First Purple 3
-    0x17D2D, // Treehouse First Purple 4
-    0x17D6C, // Treehouse First Purple 5
-    0x17D97, // Treehouse Second Purple 4
-    0x17BDF, // Treehouse Second Purple 5
-    0x17DC6, // Treehouse Second Purple 7
-    0x17DC0, // Treehouse Left Orange 4
-    0x17DD9, // Treehouse Left Orange 6
-    0x17DDC, // Treehouse Left Orange 8
-    0x17DEC, // Treehouse Left Orange 12
-    0x17DDB, // Treehouse Left Orange 15
-    0x17DB2, // Treehouse Right Orange 6
-    0x17DCC, // Treehouse Right Orange 7
-    0x17DCA, // Treehouse Right Orange 8
-    0x17DB1, // Treehouse Right Orange 11
-    0x17DA2, // Treehouse Right Orange 12
+    0x09DB3, // Boathouse Erasers Shapers and Stars 1
+    0x0288C, // Treehouse Door 1
+    0x17D72, // Treehouse Yellow 1
+    0x17D8F, // Treehouse Yellow 2
+    0x17D74, // Treehouse Yellow 3
+    0x17DC2, // Treehouse Yellow 8
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DAA, // Treehouse Second Purple 3
+    0x17D91, // Treehouse Second Purple 6
+    0x17DB3, // Treehouse Left Orange 1
+    0x17DB5, // Treehouse Left Orange 2
+    0x17DB6, // Treehouse Left Orange 3
+    0x17DD7, // Treehouse Left Orange 5
+    0x17DB8, // Treehouse Left Orange 7
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DE3, // Treehouse Left Orange 11
+    0x17DAE, // Treehouse Left Orange 13
+    0x17DB0, // Treehouse Left Orange 14
+    0x17D88, // Treehouse Right Orange 1
+    0x17DB4, // Treehouse Right Orange 2
+    0x17D8C, // Treehouse Right Orange 3
+    0x17DCD, // Treehouse Right Orange 5
+    0x17D8E, // Treehouse Right Orange 9
     0x17E3C, // Treehouse Green 1
     0x17E4D, // Treehouse Green 2
     0x17E4F, // Treehouse Green 3
-    0x17FA9, // Treehouse Green Bridge Discard
-    0x17FA0, // Treehouse Laser Discard
-    0x00139, // Keep Hedges 1
-    0x019DC, // Keep Hedges 2
-    0x019E7, // Keep Hedges 3
-    0x01A0F, // Keep Hedges 4
-    0x0360E, // Keep Front Laser
-    0x03317, // Keep Back Laser
-    0x17D27, // Keep Discard
-    0x17D28, // Shipwreck Discard
-    0x00AFB, // Shipwreck Vault
-    0x2899C, // Town 25 Dots 1
-    0x28A33, // Town 25 Dots 2
-    0x28ABF, // Town 25 Dots 3
-    0x28AC0, // Town 25 Dots 4
-    0x28AC1, // Town 25 Dots 5
-    0x28A0D, // Town Church Stars
-    0x28AD9, // Town Eraser
-    0x28998, // Town Green Door
-    0x0A0C8, // Town Orange Crate
-    0x17D01, // Town Orange Crate Discard
-    0x03C08, // Town RGB Stars
-    0x03C0C, // Town RGB Stones
-    0x17C71, // Town Rooftop Discard
-    0x17F5F, // Town Windmill Door
-    0x17CF7, // Theater Discard
-    0x00B10, // Monastery Left Door
-    0x00C92, // Monastery Right Door
-    0x17C2E, // Bunker Entry Door
-    0x0056E, // Swamp Entry
-    0x00474, // Swamp Tutorial 4
-    0x00553, // Swamp Tutorial 5
-    0x0056F, // Swamp Tutorial 6
-    0x00983, // Swamp Tutorial 9
-    0x00984, // Swamp Tutorial 10
-    0x00986, // Swamp Tutorial 11
-    0x00985, // Swamp Tutorial 12
-    0x00987, // Swamp Tutorial 13
-    0x181A9, // Swamp Tutorial 14
-    0x00982, // Swamp Red 1
-    0x0097F, // Swamp Red 2
-    0x0098F, // Swamp Red 3
-    0x00990, // Swamp Red 4
-    0x17C0D, // Swamp Red Shortcut 1
-    0x17C0E, // Swamp Red Shortcut 2
-    0x00999, // Swamp Discontinuous 1
-    0x0099D, // Swamp Discontinuous 2
-    0x009A0, // Swamp Discontinuous 3
-    0x009A1, // Swamp Discontinuous 4
-    0x00008, // Swamp Rotation Tutorial 2
-    0x00009, // Swamp Rotation Tutorial 3
-    0x0000A, // Swamp Rotation Tutorial 4
-    0x009AE, // Swamp Blue Underwater 3
-    0x009AF, // Swamp Blue Underwater 4
-    0x00006, // Swamp Blue Underwater 5
-    0x003B2, // Swamp Rotation Advanced 1
-    0x00A1E, // Swamp Rotation Advanced 2
-    0x00C2E, // Swamp Rotation Advanced 3
-    0x00E3A, // Swamp Rotation Advanced 4
-    0x009A6, // Swamp Purple Tetris
-    0x00002, // Swamp Teal Underwater 1
-    0x00004, // Swamp Teal Underwater 2
-    0x00005, // Swamp Teal Underwater 3
-    0x013E6, // Swamp Teal Underwater 4
-    0x00596, // Swamp Teal Underwater 5
-    0x014D2, // Swamp Red Underwater 2
-    0x014D4, // Swamp Red Underwater 3
-    0x014D1, // Swamp Red Underwater 4
-    0x17C05, // Swamp Laser Shortcut 1
-    0x17C02, // Swamp Laser Shortcut 2
-    0x09E73, // Mountain 1 Orange 1
-    0x09E75, // Mountain 1 Orange 2
-    0x09E78, // Mountain 1 Orange 3
-    0x09E79, // Mountain 1 Orange 4
-    0x09E6C, // Mountain 1 Orange 5
-    0x09E6F, // Mountain 1 Orange 6
-    0x09E6B, // Mountain 1 Orange 7
-    0x09EAD, // Mountain 1 Purple 1
-    0x09EAF, // Mountain 1 Purple 2
-    0x09E7A, // Mountain 1 Green 1
-    0x09E71, // Mountain 1 Green 2
-    0x09E72, // Mountain 1 Green 3
-    0x09E69, // Mountain 1 Green 4
-    0x09E7B, // Mountain 1 Green 5
-    0x09FD3, // Mountain 2 Rainbow 1
-    0x09FD4, // Mountain 2 Rainbow 2
-    0x09FD6, // Mountain 2 Rainbow 3
-    0x09FD7, // Mountain 2 Rainbow 4
-    0x17F93, // Mountain 2 Discard
-    0x17FA2, // Mountain 3 Secret Door
-    0x17C42, // Mountainside Discard
-    0x00FF8, // UTM Entrance Door
-    0x0A16B, // UTM Green Dots 1
-    0x0A2CE, // UTM Green Dots 2
-    0x0A2D7, // UTM Green Dots 3
-    0x0A2DD, // UTM Green Dots 4
-    0x0A2EA, // UTM Green Dots 5
-    0x17FB9, // UTM Green Dots 6
-    0x0008F, // UTM Invisible Dots 1
-    0x0006B, // UTM Invisible Dots 2
-    0x0008B, // UTM Invisible Dots 3
-    0x0008C, // UTM Invisible Dots 4
-    0x0008A, // UTM Invisible Dots 5
-    0x00089, // UTM Invisible Dots 6
-    0x0006A, // UTM Invisible Dots 7
-    0x0006C, // UTM Invisible Dots 8
-    0x021D7, // UTM Mountainside Shortcut
-    0x00B71, // UTM Quarry
-    0x01A31, // UTM Rainbow
-    0x32962, // UTM Swamp
-    0x17CF2, // UTM Waterfall Shortcut
-    0x00A72, // UTM Blue Cave In
-    0x009A4, // UTM Blue Discontinuous
-    0x008B8, // UTM Blue Left 1
-    0x00973, // UTM Blue Left 2
-    0x0097B, // UTM Blue Left 3
-    0x0097D, // UTM Blue Left 4
-    0x0097E, // UTM Blue Left 5
-    0x00994, // UTM Blue Right Far 1
-    0x334D5, // UTM Blue Right Far 2
-    0x00995, // UTM Blue Right Far 3
-    0x00996, // UTM Blue Right Far 4
-    0x00998, // UTM Blue Right Far 5
-    0x00190, // UTM Blue Right Near 1
-    0x00558, // UTM Blue Right Near 2
-    0x00567, // UTM Blue Right Near 3
-    0x006FE, // UTM Blue Right Near 4
-    0x0A16E, // UTM Challenge Entrance
-    0x039B4, // Tunnels Theater Catwalk
-
-    0x03612, // Quarry Laser
+    0x28938, // Town Apple Tree
+    0x28AC7, // Town Blue 1
+    0x28AC8, // Town Blue 2
+    0x28ACA, // Town Blue 3
+    0x28ACB, // Town Blue 4
+    0x28ACC, // Town Blue 5
+    0x17F89, // Theater Entrance
+    0x33AB2, // Theater Corona Exit
+    0x0A168, // Theater Sun Exit
+    0x00469, // Swamp Tutorial 1
+    0x00472, // Swamp Tutorial 2
+    0x00262, // Swamp Tutorial 3
+    0x00390, // Swamp Tutorial 7
+    0x010CA, // Swamp Tutorial 8
+    0x00007, // Swamp Rotation Tutorial 1
+    0x009AB, // Swamp Blue Underwater 1
+    0x009AD, // Swamp Blue Underwater 2
+    0x00001, // Swamp Red Underwater 1
+    0x17F9B, // Jungle Discard
+    0x002A6, // Mountainside Vault
+    0x0042D, // Mountaintop River
+    0x00027, // UTM Invisible Dots Symmetry 1
+    0x00028, // UTM Invisible Dots Symmetry 2
+    0x00029, // UTM Invisible Dots Symmetry 3
+    0x32966, // UTM Treehouse
+    0x018A0, // UTM Blue Easy Symmetry
+    0x01A0D, // UTM Blue Hard Symmetry
+    0x09E85, // Tunnels Town Shortcut
 };
 
 std::vector<int> squarePanels = {

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -236,12 +236,19 @@ std::vector<int> quarryLaserBanned = {
     0x00024, // Symmetry Island Black Dots 3
     0x00025, // Symmetry Island Black Dots 4
     0x00026, // Symmetry Island Black Dots 5
-    0x00079, // Symmetry Island Colored Dots 6
-    0x00065, // Symmetry Island Fading Lines 1
+    0x0007C, // Symmetry Island Colored Dots 1
+    0x0007E, // Symmetry Island Colored Dots 2
+    0x00075, // Symmetry Island Colored Dots 3
+    0x00073, // Symmetry Island Colored Dots 4
+    0x00077, // Symmetry Island Colored Dots 5
+    0x0006D, // Symmetry Island Fading Lines 2
+    0x00072, // Symmetry Island Fading Lines 3
+    0x0006F, // Symmetry Island Fading Lines 4
+    0x00070, // Symmetry Island Fading Lines 5
+    0x00071, // Symmetry Island Fading Lines 6
+    0x00076, // Symmetry Island Fading Lines 7
     0x01E5A, // Mill Entry Door Left
     0x3C125, // Mill Control Room 2
-    0x03677, // Mill Stairs Control
-    0x17CF0, // Mill Discard
     0x09DB3, // Boathouse Erasers Shapers and Stars 1
     0x0288C, // Treehouse Door 1
     0x17D72, // Treehouse Yellow 1
@@ -266,9 +273,11 @@ std::vector<int> quarryLaserBanned = {
     0x17D8C, // Treehouse Right Orange 3
     0x17DCD, // Treehouse Right Orange 5
     0x17D8E, // Treehouse Right Orange 9
-    0x17E3C, // Treehouse Green 1
-    0x17E4D, // Treehouse Green 2
-    0x17E4F, // Treehouse Green 3
+    0x17E5B, // Treehouse Green 5
+    0x17E5F, // Treehouse Green 6
+    0x17E61, // Treehouse Green 7
+    0x17FA9, // Treehouse Green Bridge Discard
+    0x17FA0, // Treehouse Laser Discard
     0x28938, // Town Apple Tree
     0x28AC7, // Town Blue 1
     0x28AC8, // Town Blue 2

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -276,8 +276,6 @@ std::vector<int> quarryLaserBanned = {
     0x17E5B, // Treehouse Green 5
     0x17E5F, // Treehouse Green 6
     0x17E61, // Treehouse Green 7
-    0x17FA9, // Treehouse Green Bridge Discard
-    0x17FA0, // Treehouse Laser Discard
     0x28938, // Town Apple Tree
     0x28AC7, // Town Blue 1
     0x28AC8, // Town Blue 2

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -25,21 +25,6 @@ std::vector<int> townWindmillControlOptions = {
     0x17D02, // Town Windmill Control
 };
 
-std::vector<int> symmetryDoorTwoOptions = {
-    0x00070, // Symmetry Island Fading Lines 5
-    0x01E5A, // Mill Entry Door Left
-    0x28AC7, // Town Blue 1
-    0x28AC8, // Town Blue 2
-    0x28ACA, // Town Blue 3
-    0x28ACB, // Town Blue 4
-    0x28ACC, // Town Blue 5
-    0x00029, // UTM Invisible Dots Symmetry 3
-    0x288AA, // UTM Perspective 4
-    0x17CC4, // Mill Elevator Control
-
-    0x1C349, // Inner Symmetry Island Entrance
-};
-
 std::vector<int> millElevatorControlOptions = {
     0x0008D, // Glass Factory Rotational Symmetry 1
     0x00081, // Glass Factory Rotational Symmetry 2
@@ -304,6 +289,85 @@ std::vector<int> quarryLaserBanned = {
     0x018A0, // UTM Blue Easy Symmetry
     0x01A0D, // UTM Blue Hard Symmetry
     0x09E85, // Tunnels Town Shortcut
+};
+
+std::vector<int> symmetryDoorTwoBanned = {
+    0x00182, // Tutorial Bend
+    0x0005E, // Outside Tutorial Dots Tutorial 2
+    0x0005F, // Outside Tutorial Dots Tutorial 3
+    0x00060, // Outside Tutorial Dots Tutorial 4
+    0x00061, // Outside Tutorial Dots Tutorial 5
+    0x012C9, // Outside Tutorial Stones Tutorial 3
+    0x0001D, // Outside Tutorial Stones Tutorial 5
+    0x0001E, // Outside Tutorial Stones Tutorial 6
+    0x17CFB, // Outside Tutorial Discard
+    0x3C12B, // Glass Factory Discard
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00081, // Glass Factory Rotational Symmetry 2
+    0x00022, // Symmetry Island Black Dots 1
+    0x00023, // Symmetry Island Black Dots 2
+    0x0007E, // Symmetry Island Colored Dots 2
+    0x00073, // Symmetry Island Colored Dots 4
+    0x17CE7, // Desert Discard
+    0x014D9, // Mill Lower Row 4
+    0x005F1, // Mill Upper Row 2
+    0x00620, // Mill Upper Row 3
+    0x009F5, // Mill Upper Row 4
+    0x014E9, // Mill Upper Row 8
+    0x17CF0, // Mill Discard
+    0x021B3, // Boathouse Erasers and Shapers 1
+    0x021AF, // Boathouse Erasers and Shapers 4
+    0x021B5, // Boathouse Erasers and Stars 1
+    0x021B6, // Boathouse Erasers and Stars 2
+    0x17D72, // Treehouse Yellow 1
+    0x17D9C, // Treehouse Yellow 7
+    0x17DC2, // Treehouse Yellow 8
+    0x17DC8, // Treehouse First Purple 1
+    0x17DC7, // Treehouse First Purple 2
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DAA, // Treehouse Second Purple 3
+    0x17D97, // Treehouse Second Purple 4
+    0x17BDF, // Treehouse Second Purple 5
+    0x17DD9, // Treehouse Left Orange 6
+    0x17DB8, // Treehouse Left Orange 7
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DE3, // Treehouse Left Orange 11
+    0x17D8C, // Treehouse Right Orange 3
+    0x17FA9, // Treehouse Green Bridge Discard
+    0x17FA0, // Treehouse Laser Discard
+    0x17D27, // Keep Discard
+    0x17D28, // Shipwreck Discard
+    0x17D01, // Town Orange Crate Discard
+    0x17C71, // Town Rooftop Discard
+    0x17CF7, // Theater Discard
+    0x0056E, // Swamp Entry
+    0x00472, // Swamp Tutorial 2
+    0x00262, // Swamp Tutorial 3
+    0x00553, // Swamp Tutorial 5
+    0x00390, // Swamp Tutorial 7
+    0x010CA, // Swamp Tutorial 8
+    0x00983, // Swamp Tutorial 9
+    0x00984, // Swamp Tutorial 10
+    0x00986, // Swamp Tutorial 11
+    0x00985, // Swamp Tutorial 12
+    0x00987, // Swamp Tutorial 13
+    0x181A9, // Swamp Tutorial 14
+    0x00999, // Swamp Discontinuous 1
+    0x0099D, // Swamp Discontinuous 2
+    0x00008, // Swamp Rotation Tutorial 2
+    0x009AB, // Swamp Blue Underwater 1
+    0x00001, // Swamp Red Underwater 1
+    0x014D2, // Swamp Red Underwater 2
+    0x17F93, // Mountain 2 Discard
+    0x17C42, // Mountainside Discard
+    0x17FB9, // UTM Green Dots 6
+    0x0008F, // UTM Invisible Dots 1
+    0x0008B, // UTM Invisible Dots 3
+    0x0008C, // UTM Invisible Dots 4
+    0x00B71, // UTM Quarry
 };
 
 std::vector<int> squarePanels = {

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -572,6 +572,7 @@ std::vector<int> squarePanels = {
     0x09FD4, // Mountain 2 Rainbow 2
     0x09FD6, // Mountain 2 Rainbow 3
     0x09FD7, // Mountain 2 Rainbow 4
+    0x09FD8, // Mountain 2 Rainbow 5
     0x17F93, // Mountain 2 Discard
     0x17FA2, // Mountain 3 Secret Door
     0x17C42, // Mountainside Discard

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -198,6 +198,84 @@ std::vector<int> mountainBlueOneOptions = {
     0x33AF5, // Mountain 1 Blue 1
 };
 
+std::vector<int> mountainBlueTwoOptions = {
+    0x00182, // Tutorial Bend
+    0x00293, // Tutorial Front Center
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x00087, // Glass Factory Vertical Symmetry 2
+    0x00059, // Glass Factory Vertical Symmetry 3
+    0x00062, // Glass Factory Vertical Symmetry 4
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00081, // Glass Factory Rotational Symmetry 2
+    0x00084, // Glass Factory Melting 1
+    0x00082, // Glass Factory Melting 2
+    0x0343A, // Glass Factory Melting 3
+    0x00026, // Symmetry Island Black Dots 5
+    0x0007C, // Symmetry Island Colored Dots 1
+    0x00075, // Symmetry Island Colored Dots 3
+    0x00073, // Symmetry Island Colored Dots 4
+    0x00065, // Symmetry Island Fading Lines 1
+    0x0006D, // Symmetry Island Fading Lines 2
+    0x00072, // Symmetry Island Fading Lines 3
+    0x0006F, // Symmetry Island Fading Lines 4
+    0x00070, // Symmetry Island Fading Lines 5
+    0x17CE7, // Desert Discard
+    0x00557, // Mill Upper Row 1
+    0x00620, // Mill Upper Row 3
+    0x021B4, // Boathouse Erasers and Shapers 2
+    0x021AF, // Boathouse Erasers and Shapers 4
+    0x021B5, // Boathouse Erasers and Stars 1
+    0x021B6, // Boathouse Erasers and Stars 2
+    0x021B7, // Boathouse Erasers and Stars 3
+    0x0288C, // Treehouse Door 1
+    0x17D8F, // Treehouse Yellow 2
+    0x17D74, // Treehouse Yellow 3
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DB5, // Treehouse Left Orange 2
+    0x17DB6, // Treehouse Left Orange 3
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DE3, // Treehouse Left Orange 11
+    0x17DB0, // Treehouse Left Orange 14
+    0x17D88, // Treehouse Right Orange 1
+    0x17DB4, // Treehouse Right Orange 2
+    0x17DCD, // Treehouse Right Orange 5
+    0x17D8E, // Treehouse Right Orange 9
+    0x17E5B, // Treehouse Green 5
+    0x019E7, // Keep Hedges 3
+    0x28938, // Town Apple Tree
+    0x28AC7, // Town Blue 1
+    0x28AC8, // Town Blue 2
+    0x28ACA, // Town Blue 3
+    0x17C2E, // Bunker Entry Door
+    0x0056E, // Swamp Entry
+    0x0098F, // Swamp Red 3
+    0x00999, // Swamp Discontinuous 1
+    0x00007, // Swamp Rotation Tutorial 1
+    0x00008, // Swamp Rotation Tutorial 2
+    0x00009, // Swamp Rotation Tutorial 3
+    0x009AE, // Swamp Blue Underwater 3
+    0x009AF, // Swamp Blue Underwater 4
+    0x009A6, // Swamp Purple Tetris
+    0x00001, // Swamp Red Underwater 1
+    0x014D2, // Swamp Red Underwater 2
+    0x014D4, // Swamp Red Underwater 3
+    0x17C02, // Swamp Laser Shortcut 2
+    0x17F9B, // Jungle Discard
+    0x09E7B, // Mountain 1 Green 5
+    0x09FD3, // Mountain 2 Rainbow 1
+    0x17F93, // Mountain 2 Discard
+    0x0042D, // Mountaintop River
+    0x0008F, // UTM Invisible Dots 1
+    0x00027, // UTM Invisible Dots Symmetry 1
+    0x00028, // UTM Invisible Dots Symmetry 2
+    0x00029, // UTM Invisible Dots Symmetry 3
+    0x018A0, // UTM Blue Easy Symmetry
+
+    0x33AF7, // Mountain 1 Blue 2
+};
+
 std::vector<int> utmElevatorControls = {
     0x335AB, // UTM In Elevator Control
     0x3369D, // UTM Lower Elevator Control

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -440,7 +440,7 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
 }
 
 // Range is [start, end)
-void Randomizer::Shuffle(std::vector<int> &order, size_t startIndex, size_t endIndex) {
+void Randomizer::Shuffle(std::vector<int>& order, size_t startIndex, size_t endIndex) {
     if (order.size() == 0) return;
     if (startIndex >= endIndex) return;
     if (endIndex >= order.size()) endIndex = static_cast<int>(order.size());
@@ -455,10 +455,12 @@ void Randomizer::RandomizeRange(std::vector<int> panels, int flags, size_t start
     if (panels.size() == 0) return;
     if (startIndex >= endIndex) return;
     if (endIndex >= panels.size()) endIndex = static_cast<int>(panels.size());
-    for (size_t i = endIndex-1; i > startIndex; i--) {
+    for (size_t i = endIndex - 1; i > startIndex; i--) {
         const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
         if (i != target) {
-            std::swap(panels[i], panels[target]);
+            // std::cout << "Swapping panels " << std::hex << panels[i] << " and " << std::hex << panels[target] << std::endl;
+            SwapPanels(panels[i], panels[target], flags);
+            std::swap(panels[i], panels[target]); // Panel indices in the array
         }
     }
 }

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -454,7 +454,7 @@ void Randomizer::Shuffle(std::vector<int> &order, size_t startIndex, size_t endI
     if (order.size() == 0) return;
     if (startIndex >= endIndex) return;
     if (endIndex >= order.size()) endIndex = static_cast<int>(order.size());
-    for (size_t i = endIndex-1; i > startIndex; i--) {
+    for (size_t i = endIndex - 1; i > startIndex; i--) {
         const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
         std::swap(order[i], order[target]);
     }
@@ -465,7 +465,7 @@ void Randomizer::RandomizeRange(std::vector<int> panels, int flags, size_t start
     if (panels.size() == 0) return;
     if (startIndex >= endIndex) return;
     if (endIndex >= panels.size()) endIndex = static_cast<int>(panels.size());
-    for (size_t i = endIndex - 1; i > startIndex; i--) {
+    for (size_t i = endIndex-1; i > startIndex; i--) {
         const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
         if (i != target) {
             // std::cout << "Swapping panels " << std::hex << panels[i] << " and " << std::hex << panels[target] << std::endl;

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -439,12 +439,22 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
     return RandomizeRange(panels, flags, 0, panels.size());
 }
 
+void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
+    std::vector<int> filtered = copyWithoutElements(possible_panels, _alreadySwapped);
+    const int target = Random::RandInt(0, static_cast<int>(filtered.size()) - 1);
+    const int toSwap = filtered[target];
+    if (panel1 != toSwap) {
+        SwapPanels(panel1, toSwap, flags);
+    }
+    _alreadySwapped.push_back(toSwap);
+}
+
 // Range is [start, end)
-void Randomizer::Shuffle(std::vector<int>& order, size_t startIndex, size_t endIndex) {
+void Randomizer::Shuffle(std::vector<int> &order, size_t startIndex, size_t endIndex) {
     if (order.size() == 0) return;
     if (startIndex >= endIndex) return;
     if (endIndex >= order.size()) endIndex = static_cast<int>(order.size());
-    for (size_t i = endIndex - 1; i > startIndex; i--) {
+    for (size_t i = endIndex-1; i > startIndex; i--) {
         const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
         std::swap(order[i], order[target]);
     }
@@ -463,16 +473,6 @@ void Randomizer::RandomizeRange(std::vector<int> panels, int flags, size_t start
             std::swap(panels[i], panels[target]); // Panel indices in the array
         }
     }
-}
-
-void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
-    std::vector<int> filtered = copyWithoutElements(possible_panels, _alreadySwapped);
-    const int target = Random::RandInt(0, static_cast<int>(filtered.size()) - 1);
-    const int toSwap = filtered[target];
-    if (panel1 != toSwap) {
-        SwapPanels(panel1, toSwap, flags);
-    }
-    _alreadySwapped.push_back(toSwap);
 }
 
 void Randomizer::SwapPanels(int panel1, int panel2, int flags) {

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -200,6 +200,7 @@ void Randomizer::Randomize() {
         SwapWithRandomPanel(0x17CC4, millElevatorControlOptions, SWAP::LINES | SWAP::COLORS); // Mill Elevator Control
         SwapWithRandomPanel(0x288AA, utmPerspectiveFourOptions, SWAP::LINES | SWAP::COLORS); // UTM Perspective 4
         SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+        SwapWithRandomPanel(0x33AF5, mountainBlueOneOptions, SWAP::LINES | SWAP::COLORS); // Mountain Blue 1
 
         std::vector<int> symTwoOptions = copyWithoutElements(squarePanels, symmetryDoorTwoBanned);
         symTwoOptions.push_back(0x1C349);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -201,6 +201,7 @@ void Randomizer::Randomize() {
         SwapWithRandomPanel(0x288AA, utmPerspectiveFourOptions, SWAP::LINES | SWAP::COLORS); // UTM Perspective 4
         SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
         SwapWithRandomPanel(0x33AF5, mountainBlueOneOptions, SWAP::LINES | SWAP::COLORS); // Mountain Blue 1
+        SwapWithRandomPanel(0x33AF7, mountainBlueTwoOptions, SWAP::LINES | SWAP::COLORS); // Mountain Blue 2
 
         std::vector<int> symTwoOptions = copyWithoutElements(squarePanels, symmetryDoorTwoBanned);
         symTwoOptions.push_back(0x1C349);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -151,7 +151,7 @@ void Randomizer::Randomize() {
         // is unknown whether any of the other puzzles in these pools can be
         // solved there after using Sigma's randomizer.
         // 0x288AA UTM Perspective 4
-        _alreadySwapped.push_back(0x288AA);
+        _alreadySwapped.insert(0x288AA);
         SwapWithRandomPanel(0x17CC4, millElevatorControlOptions, SWAP::LINES | SWAP::COLORS); // Mill Elevator Control
         // The pool that Tutorial Back Left is in has some panels that may not
         // be solveable in the down position after using Sigma's randomizer. We
@@ -440,13 +440,15 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
 }
 
 void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
-    std::vector<int> filtered = copyWithoutElements(possible_panels, _alreadySwapped);
-    const int target = Random::RandInt(0, static_cast<int>(filtered.size()) - 1);
-    const int toSwap = filtered[target];
+    int toSwap = -1;
+    do {
+        const int target = Random::RandInt(0, static_cast<int>(possible_panels.size()) - 1);
+        toSwap = possible_panels[target];
+    } while (_alreadySwapped.count(toSwap));
     if (panel1 != toSwap) {
         SwapPanels(panel1, toSwap, flags);
     }
-    _alreadySwapped.push_back(toSwap);
+    _alreadySwapped.insert(toSwap);
 }
 
 // Range is [start, end)

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -186,10 +186,6 @@ void Randomizer::Randomize() {
         // swapped with Swamp Entry. To make things simpler, we will just not
         // shuffle it.
         std::vector<int> squarePanelsDoubleMode = copyWithoutElements(squarePanels, doubleModeBannedSquarePanels);
-        std::vector<int> quarryLaserOptions = copyWithoutElements(squarePanelsDoubleMode, quarryLaserBanned);
-        quarryLaserOptions.push_back(0x03612);
-        SwapWithRandomPanel(0x03612, quarryLaserOptions, SWAP::LINES | SWAP::COLORS); // Quarry Laser
-
         Shuffle(squarePanelsDoubleMode, SWAP::LINES | SWAP::COLORS);
     } else {
         Shuffle(utmElevatorControls, SWAP::LINES | SWAP::COLORS);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -187,7 +187,7 @@ void Randomizer::Randomize() {
         std::vector<int> squarePanelsDoubleMode = copyWithoutElements(squarePanels, doubleModeBannedSquarePanels);
         std::vector<int> quarryLaserOptions = copyWithoutElements(squarePanelsDoubleMode, quarryLaserBanned);
         alreadySwapped.push_back(SwapWithRandomPanel(0x03612, copyWithoutElements(quarryLaserOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Quarry Laser
-        Shuffle(copyWithoutElements(squarePanelsDoubleMode, alreadySwapped), SWAP::LINES | SWAP::COLORS);
+        Shuffle(squarePanelsDoubleMode, SWAP::LINES | SWAP::COLORS);
     } else {
         Shuffle(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
         Shuffle(leftForwardRightPanelsSetOne, SWAP::LINES | SWAP::COLORS);
@@ -201,7 +201,7 @@ void Randomizer::Randomize() {
         alreadySwapped.push_back(SwapWithRandomPanel(0x0A3B5, copyWithoutElements(tutorialBackLeftOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Tutorial Back Left
         std::vector<int> quarryLaserOptions = copyWithoutElements(squarePanels, quarryLaserBanned);
         alreadySwapped.push_back(SwapWithRandomPanel(0x03612, copyWithoutElements(quarryLaserOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Quarry Laser
-        Shuffle(copyWithoutElements(squarePanels, alreadySwapped), SWAP::LINES | SWAP::COLORS);
+        Shuffle(squarePanels, SWAP::LINES | SWAP::COLORS);
     }
 
     // Individual area modifications

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -439,11 +439,11 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
     return RandomizeRange(panels, flags, 0, panels.size());
 }
 
-void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
+void Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possiblePanels, int flags) {
     int toSwap = -1;
     do {
-        const int target = Random::RandInt(0, static_cast<int>(possible_panels.size()) - 1);
-        toSwap = possible_panels[target];
+        const int target = Random::RandInt(0, static_cast<int>(possiblePanels.size()) - 1);
+        toSwap = possiblePanels[target];
     } while (_alreadySwapped.count(toSwap));
     if (panel1 != toSwap) {
         SwapPanels(panel1, toSwap, flags);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -145,11 +145,18 @@ void Randomizer::Randomize() {
 
     // Content swaps -- must happen before squarePanels
     if (_doubleRandomizer) {
+        // Prevent the fourth UTM perspective puzzle from being shuffled, as it
+        // is unknown whether any of the other puzzles in these pools can be
+        // solved there after using Sigma's randomizer.
+        // 0x288AA UTM Perspective 4
+        std::vector<int> alreadySwapped = { 0x288AA };
+        alreadySwapped.push_back(SwapWithRandomPanel(0x1C349, copyWithoutElements(symmetryDoorTwoOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Symmetry Door 2
+        alreadySwapped.push_back(SwapWithRandomPanel(0x17CC4, copyWithoutElements(millElevatorControlOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Mill Elevator Control
         // The pool that Tutorial Back Left is in has some panels that may not
         // be solveable in the down position after using Sigma's randomizer. We
         // do not want to swap any such panel with Tutorial Back Left, because
         // that would make it impossible to exit Tutorial.
-        std::vector<int> upDownPanelsSetThreeDoubleMode = copyWithoutElements(upDownPanelsSetThree, {
+        std::vector<int> tutorialBackLeftDoubleMode = copyWithoutElements(tutorialBackLeftOptions, {
             0x00070, // Symmetry Island Fading Lines 5
             0x01E5A, // Mill Entry Door Left
             0x00072, // Symmetry Island Fading 3
@@ -157,49 +164,44 @@ void Randomizer::Randomize() {
             0x3C125, // Mill Control Room Extra Panel
             0x09E85, // Tunnels Town Shortcut
         });
-        Randomize(upDownPanelsSetThreeDoubleMode, SWAP::LINES | SWAP::COLORS);
+        alreadySwapped.push_back(SwapWithRandomPanel(0x0A3B5, copyWithoutElements(tutorialBackLeftDoubleMode, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Tutorial Back Left
+        // Shuffle the UTM elevator controls amongst themselves.
+        Shuffle(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
         // The four pivot panels in Treehouse must be solveable in the up, left,
         // and right positions. However, the other panels in the pools those
         // panels are found in may not be solveable in all three directions
         // after using Sigma's randomizer. For safety, we will only swap the
         // pivot panels amongst themselves.
-        Randomize(treehousePivotSet, SWAP::LINES | SWAP::COLORS);
+        Shuffle(treehousePivotSet, SWAP::LINES | SWAP::COLORS);
         // This will additionally shuffle the UTM perspective puzzles amongst
         // themselves.
-        Randomize(utmPerspectiveSet, SWAP::LINES | SWAP::COLORS);
+        Shuffle(utmPerspectiveSet, SWAP::LINES | SWAP::COLORS);
         // In order to prevent a situation where access to a Symmetry Laser
         // Yellow is blocked by its corresponding Blue panel, we will only
         // shuffle these six panels amongst themselves.
-        Randomize(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
-        Randomize(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
-        // Prevent the fourth UTM perspective puzzle from being shuffled, as it
-        // is unknown whether any of the other puzzles in these pools can be
-        // solved there after using Sigma's randomizer.
-        // 0x288AA UTM Perspective 4
-        std::vector<int> upDownPanelsSetZeroDoubleMode = copyWithoutElements(upDownPanelsSetZero, {0x288AA});
-        std::vector<int> upDownPanelsSetOneDoubleMode = copyWithoutElements(upDownPanelsSetOne, {0x288AA});
-        std::vector<int> upDownPanelsSetTwoDoubleMode = copyWithoutElements(upDownPanelsSetTwo, {0x288AA});
-        Randomize(upDownPanelsSetZeroDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetOneDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetTwoDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetFour, SWAP::LINES | SWAP::COLORS);
+        Shuffle(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
+        Shuffle(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
         // Many puzzles either crash the game or do not solve properly when
-        // swapped with Swamp Entry. To make things simpler, we will just remove
-        // that panel from both pools it is found in.
-        std::vector<int> quarryLaserOptionsDoubleMode = copyWithoutElements(quarryLaserOptions, doubleModeBannedSquarePanels);
+        // swapped with Swamp Entry. To make things simpler, we will just not
+        // shuffle it.
         std::vector<int> squarePanelsDoubleMode = copyWithoutElements(squarePanels, doubleModeBannedSquarePanels);
-        Randomize(quarryLaserOptionsDoubleMode, SWAP::LINES | SWAP::COLORS);
-        Randomize(squarePanelsDoubleMode, SWAP::LINES | SWAP::COLORS);
+        std::vector<int> quarryLaserOptions = copyWithoutElements(squarePanelsDoubleMode, quarryLaserBanned);
+        alreadySwapped.push_back(SwapWithRandomPanel(0x03612, copyWithoutElements(quarryLaserOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Quarry Laser
+        Shuffle(copyWithoutElements(squarePanelsDoubleMode, alreadySwapped), SWAP::LINES | SWAP::COLORS);
     } else {
-        Randomize(upDownPanelsSetZero, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetOne, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetTwo, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetThree, SWAP::LINES | SWAP::COLORS);
-        Randomize(upDownPanelsSetFour, SWAP::LINES | SWAP::COLORS);
-        Randomize(leftForwardRightPanelsSetOne, SWAP::LINES | SWAP::COLORS);
-        Randomize(leftForwardRightPanelsSetTwo, SWAP::LINES | SWAP::COLORS);
-        Randomize(quarryLaserOptions, SWAP::LINES | SWAP::COLORS);
-        Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
+        Shuffle(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
+        Shuffle(leftForwardRightPanelsSetOne, SWAP::LINES | SWAP::COLORS);
+        Shuffle(leftForwardRightPanelsSetTwo, SWAP::LINES | SWAP::COLORS);
+
+        std::vector<int> alreadySwapped;
+        alreadySwapped.push_back(SwapWithRandomPanel(0x17D02, townWindmillControlOptions, SWAP::LINES | SWAP::COLORS)); // Town Windmill Control
+        alreadySwapped.push_back(SwapWithRandomPanel(0x1C349, copyWithoutElements(symmetryDoorTwoOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Symmetry Door 2
+        alreadySwapped.push_back(SwapWithRandomPanel(0x17CC4, copyWithoutElements(millElevatorControlOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Mill Elevator Control
+        alreadySwapped.push_back(SwapWithRandomPanel(0x288AA, copyWithoutElements(utmPerspectiveFourOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // UTM Perspective 4
+        alreadySwapped.push_back(SwapWithRandomPanel(0x0A3B5, copyWithoutElements(tutorialBackLeftOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Tutorial Back Left
+        std::vector<int> quarryLaserOptions = copyWithoutElements(squarePanels, quarryLaserBanned);
+        alreadySwapped.push_back(SwapWithRandomPanel(0x03612, copyWithoutElements(quarryLaserOptions, alreadySwapped), SWAP::LINES | SWAP::COLORS)); // Quarry Laser
+        Shuffle(copyWithoutElements(squarePanels, alreadySwapped), SWAP::LINES | SWAP::COLORS);
     }
 
     // Individual area modifications
@@ -229,7 +231,7 @@ void Randomizer::AdjustSpeed() {
 }
 
 void Randomizer::RandomizeLasers() {
-    Randomize(lasers, SWAP::TARGETS);
+    Shuffle(lasers, SWAP::TARGETS);
     // Read the target of keep front laser, and write it to keep back laser.
     std::vector<int> keepFrontLaserTarget = _memory->ReadEntityData<int>(0x0360E, TARGET, 1);
     _memory->WriteEntityData<int>(0x03317, TARGET, keepFrontLaserTarget);
@@ -260,13 +262,13 @@ void Randomizer::RandomizeTutorial() {
 void Randomizer::RandomizeSymmetry() {
     std::vector<int> randomOrder(transparent.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    RandomizeRange(randomOrder, SWAP::NONE, 1, 5);
+    ReorderRange(randomOrder, 1, 5);
     ReassignTargets(transparent, randomOrder);
 }
 
 void Randomizer::RandomizeDesert() {
-    Randomize(desertPanels, SWAP::LINES);
-    Randomize(desertPanelsWide, SWAP::LINES);
+    Shuffle(desertPanels, SWAP::LINES);
+    Shuffle(desertPanelsWide, SWAP::LINES);
 
     // Turn off desert surface 8
     _memory->WriteEntityData<float>(0x09F94, POWER, {0.0, 0.0});
@@ -302,9 +304,9 @@ void Randomizer::RandomizeShadows() {
 
     std::vector<int> randomOrder(shadowsPanels.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    RandomizeRange(randomOrder, SWAP::NONE, 0, 8); // Tutorial
-    RandomizeRange(randomOrder, SWAP::NONE, 8, 16); // Avoid
-    RandomizeRange(randomOrder, SWAP::NONE, 16, 21); // Follow
+    ReorderRange(randomOrder, 0, 8); // Tutorial
+    ReorderRange(randomOrder, 8, 16); // Avoid
+    ReorderRange(randomOrder, 16, 21); // Follow
     ReassignTargets(shadowsPanels, randomOrder);
     // Turn off original starting panel
     _memory->WriteEntityData<float>(shadowsPanels[0], POWER, {0.0f, 0.0f});
@@ -316,7 +318,7 @@ void Randomizer::RandomizeTown() {
     // @Hack...? To open the gate at the end
     std::vector<int> randomOrder(orchard.size() + 1, 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    RandomizeRange(randomOrder, SWAP::NONE, 1, 5);
+    ReorderRange(randomOrder, 1, 5);
     // Ensure that we open the gate before the final puzzle (by swapping)
     int panel3Index = find(randomOrder, 3);
     int panel4Index = find(randomOrder, 4);
@@ -328,7 +330,7 @@ void Randomizer::RandomizeTown() {
 void Randomizer::RandomizeMonastery() {
     std::vector<int> randomOrder(monasteryPanels.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    RandomizeRange(randomOrder, SWAP::NONE, 3, 9); // Outer 2 & 3, Inner 1-4
+    ReorderRange(randomOrder, 3, 9); // Outer 2 & 3, Inner 1-4
     ReassignTargets(monasteryPanels, randomOrder);
 }
 
@@ -338,10 +340,10 @@ void Randomizer::RandomizeBunker() {
     // Randomize Tutorial 2-Advanced Tutorial 4 + Glass 1
     // Tutorial 1 cannot be randomized, since no other panel can start on
     // Glass 1 will become door + glass 1, due to the targetting system
-    RandomizeRange(randomOrder, SWAP::NONE, 1, 10);
+    ReorderRange(randomOrder, 1, 10);
     // Randomize Glass 1-3 into everything after the door/glass 1
     const size_t glass1Index = find(randomOrder, 9);
-    RandomizeRange(randomOrder, SWAP::NONE, glass1Index + 1, 12);
+    ReorderRange(randomOrder, glass1Index + 1, 12);
     ReassignTargets(bunkerPanels, randomOrder);
 }
 
@@ -349,8 +351,8 @@ void Randomizer::RandomizeJungle() {
     std::vector<int> randomOrder(junglePanels.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
     // Waves 1 cannot be randomized, since no other panel can start on
-    RandomizeRange(randomOrder, SWAP::NONE, 1, 7); // Waves 2-7
-    RandomizeRange(randomOrder, SWAP::NONE, 8, 13); // Pitches 1-6
+    ReorderRange(randomOrder, 1, 7); // Waves 2-7
+    ReorderRange(randomOrder, 8, 13); // Pitches 1-6
     ReassignTargets(junglePanels, randomOrder);
 
     // Fix the wall's target to point back to the cable, and the cable to point to the pitches panel.
@@ -364,12 +366,12 @@ void Randomizer::RandomizeSwamp() {
 
 void Randomizer::RandomizeMountain() {
     // Randomize multipanel
-    Randomize(mountainMultipanel, SWAP::LINES | SWAP::COLORS);
+    Shuffle(mountainMultipanel, SWAP::LINES | SWAP::COLORS);
     // With Sigma's randomizer, split solution metapuzzles may become impossible
     // if the interior panels are shuffled, so we will just not shuffle them in
     // double randomizer mode.
     if (!_doubleRandomizer) {
-        Randomize(mountainMetaPanels, SWAP::LINES | SWAP::COLORS);
+        Shuffle(mountainMetaPanels, SWAP::LINES | SWAP::COLORS);
     }
 
     // Randomize final pillars order
@@ -382,8 +384,8 @@ void Randomizer::RandomizeMountain() {
 
     std::vector<int> randomOrder(pillars.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    RandomizeRange(randomOrder, SWAP::NONE, 0, 4); // Left Pillars 1-4
-    RandomizeRange(randomOrder, SWAP::NONE, 5, 9); // Right Pillars 1-4
+    ReorderRange(randomOrder, 0, 4); // Left Pillars 1-4
+    ReorderRange(randomOrder, 5, 9); // Right Pillars 1-4
     ReassignTargets(pillars, randomOrder, targets);
     // Turn off original starting panels
     _memory->WriteEntityData<float>(pillars[0], POWER, {0.0f, 0.0f});
@@ -403,27 +405,40 @@ void Randomizer::RandomizeChallenge() {
 void Randomizer::RandomizeAudioLogs() {
     std::vector<int> randomOrder(audiologs.size(), 0);
     std::iota(randomOrder.begin(), randomOrder.end(), 0);
-    Randomize(randomOrder, SWAP::NONE);
+    ReorderRange(randomOrder, 0, audiologs.size());
     ReassignNames(audiologs, randomOrder);
 }
 
-void Randomizer::Randomize(std::vector<int>& panels, int flags) {
-    return RandomizeRange(panels, flags, 0, panels.size());
-}
-
-// Range is [start, end)
-void Randomizer::RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex) {
-    if (panels.size() == 0) return;
-    if (startIndex >= endIndex) return;
-    if (endIndex >= panels.size()) endIndex = static_cast<int>(panels.size());
-    for (size_t i = endIndex-1; i > startIndex; i--) {
-        const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
+void Randomizer::Shuffle(std::vector<int> panels, int flags) {
+    for (size_t i = panels.size() - 1; i > 0; i--) {
+        const int target = Random::RandInt(0, static_cast<int>(i));
         if (i != target) {
             // std::cout << "Swapping panels " << std::hex << panels[i] << " and " << std::hex << panels[target] << std::endl;
             SwapPanels(panels[i], panels[target], flags);
             std::swap(panels[i], panels[target]); // Panel indices in the array
         }
     }
+}
+
+// Range is [start, end)
+void Randomizer::ReorderRange(std::vector<int>& panels, size_t startIndex, size_t endIndex) {
+    if (panels.size() == 0) return;
+    if (startIndex >= endIndex) return;
+    if (endIndex >= panels.size()) endIndex = static_cast<int>(panels.size());
+    for (size_t i = endIndex-1; i > startIndex; i--) {
+        const int target = Random::RandInt(static_cast<int>(startIndex), static_cast<int>(i));
+        if (i != target) {
+            std::swap(panels[i], panels[target]);
+        }
+    }
+}
+
+int Randomizer::SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags) {
+    const int target = Random::RandInt(0, static_cast<int>(possible_panels.size()) - 1);
+    if (panel1 != possible_panels[target]) {
+        SwapPanels(panel1, possible_panels[target], flags);
+    }
+    return possible_panels[target];
 }
 
 void Randomizer::SwapPanels(int panel1, int panel2, int flags) {

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Memory.h"
 #include <memory>
+#include <set>
 
 class Randomizer {
 public:
@@ -50,7 +51,7 @@ private:
     std::shared_ptr<Memory> _memory;
     bool _doubleRandomizer = false;
     bool _preventDesertSkips = false;
-    std::vector<int> _alreadySwapped;
+    std::set<int> _alreadySwapped;
 
     friend class SwapTests_Shipwreck_Test;
 };

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -40,7 +40,7 @@ private:
     void RandomizeAudioLogs();
 
     void Randomize(std::vector<int>& panels, int flags);
-    int SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
+    void SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
     void Shuffle(std::vector<int>& order, size_t startIndex, size_t endIndex);
     void RandomizeRange(std::vector<int> panels, int flags, size_t startIndex, size_t endIndex);
     void SwapPanels(int panel1, int panel2, int flags);

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -40,13 +40,14 @@ private:
 
     void Shuffle(std::vector<int> panels, int flags);
     void ReorderRange(std::vector<int>& panels, size_t startIndex, size_t endIndex);
-    int SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
+    void SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
     void SwapPanels(int panel1, int panel2, int flags);
     void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});
     void ReassignNames(const std::vector<int>& panels, const std::vector<int>& order);
 
     std::shared_ptr<Memory> _memory;
     bool _doubleRandomizer = false;
+    std::vector<int> _alreadySwapped;
 
     friend class SwapTests_Shipwreck_Test;
 };

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -38,8 +38,9 @@ private:
     void RandomizeMountain();
     void RandomizeAudioLogs();
 
-    void Randomize(std::vector<int>& panels, int flags);
-    void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
+    void Shuffle(std::vector<int> panels, int flags);
+    void ReorderRange(std::vector<int>& panels, size_t startIndex, size_t endIndex);
+    int SwapWithRandomPanel(int panel1, const std::vector<int>& possible_panels, int flags);
     void SwapPanels(int panel1, int panel2, int flags);
     void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});
     void ReassignNames(const std::vector<int>& panels, const std::vector<int>& order);


### PR DESCRIPTION
There are a number of panel pools intended just to make sure that a specific panel placement receives an appropriate swap (Quarry Laser, Town Windmill Control, Mill Elevator Control, Symmetry Door 2, and UTM Perspective 4). Previously, every panel within each pool was shuffled amongst themselves, which, combined with the fact that some panels were in multiple pools, could cause a butterfly effect where some panels ended up swapped with something that they did not share a pool with. This change makes it so that each special panel is swapped with a single other panel from its respective pool, and then both the special panel and the panel it was swapped with are no longer available for swapping.

quarryLaserOptions was inverted to being quarryLaserBanned because it is much smaller as an exclusion list.

Double randomizer mode no longer shuffles Symmetry Door 2 or Quarry Laser, because I'm not convinced that the current pool of panels there are actually guaranteed to pass through the latches after applying Sigma's randomiser.

The following previously un-randomised panels are now shuffled: Town Windmill Control, Mountain Rainbow 5, Mountain Blue 1, Mountain Blue 2 (only Rainbow 5 is affected in double mode, however).